### PR TITLE
Use lazy % formatting for `logging` calls

### DIFF
--- a/src/apb_dashboard/entrypoint.py
+++ b/src/apb_dashboard/entrypoint.py
@@ -61,7 +61,7 @@ def main() -> None:
         sys.exit(-1)
 
     # Read json data created by apb action
-    logging.info(f"Loading json data from: {read_filename}")
+    logging.info("Loading json data from: %s", read_filename)
     with (Path(github_workspace_dir) / Path(read_filename)).open() as f:
         data = json.load(f)
 
@@ -74,7 +74,7 @@ def main() -> None:
 
     # Render the internal or external template
     if template_filename:
-        logging.info(f"Loading template file: {template_filename}")
+        logging.info("Loading template file: %s", template_filename)
         with (Path(github_workspace_dir) / Path(template_filename)).open() as f:
             template_data: str = f.read()
             logging.info("Rendering template from external file.")
@@ -84,6 +84,6 @@ def main() -> None:
         rendered = pystache.render(TEMPLATE, data)
 
     # Write rendered data out to file
-    logging.info(f"Writing rendered data to: {write_filename}")
+    logging.info("Writing rendered data to: %s", write_filename)
     with (Path(github_workspace_dir) / Path(write_filename)).open("w") as f:
         f.write(rendered)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request convert all calls using the `logging` library to use lazy % formatting instead of f-strings.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The use of % formatting in `logging` calls is preferred for a number of reasons. This also brings this project in line with our other Python projects that already follow this preference.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
