### PR TITLE
Replace the `Pystache` package with `chevron`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["pystache", "python-dateutil", "setuptools >= 24.2.0"],
+    install_requires=["chevron", "python-dateutil", "setuptools >= 24.2.0"],
     extras_require={
         "test": [
             "coverage",

--- a/src/apb_dashboard/entrypoint.py
+++ b/src/apb_dashboard/entrypoint.py
@@ -9,7 +9,7 @@ import sys
 from typing import Optional
 
 # Third-Party Libraries
-import pystache
+import chevron
 
 TEMPLATE = """
 # APB Status
@@ -78,10 +78,10 @@ def main() -> None:
         with (Path(github_workspace_dir) / Path(template_filename)).open() as f:
             template_data: str = f.read()
             logging.info("Rendering template from external file.")
-            rendered = pystache.render(template_data, data)
+            rendered = chevron.render(template_data, data)
     else:
         logging.info("Rendering default template.")
-        rendered = pystache.render(TEMPLATE, data)
+        rendered = chevron.render(TEMPLATE, data)
 
     # Write rendered data out to file
     logging.info("Writing rendered data to: %s", write_filename)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request replaces the [Pystache] package with the [chevron] package for rendering [Mustache] templates.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are moving away from [Pystache] due to the fact that it is:
- Out of date as the last commit was 2014-09-30
- Not up-to-date with the [Mustache] specification

[chevron] alleviates both of those concerns while also claiming superior speed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested this branch in [this Actions run](https://github.com/cisagov/action-apb/actions/runs/1716660942) and there were no issues.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[Pystache]: https://github.com/defunkt/pystache
[chevron]: https://github.com/noahmorrison/chevron
[Mustache]: https://mustache.github.io/