### PR TITLE
Prefer chevron to pystache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["pystache", "python-dateutil", "setuptools >= 24.2.0"],
+    install_requires=["chevron", "python-dateutil", "setuptools >= 24.2.0"],
     extras_require={
         "test": [
             "coverage",

--- a/src/apb_dashboard/entrypoint.py
+++ b/src/apb_dashboard/entrypoint.py
@@ -9,7 +9,7 @@ import sys
 from typing import Optional
 
 # Third-Party Libraries
-import pystache
+import chevron
 
 TEMPLATE = """
 # APB Status
@@ -78,10 +78,10 @@ def main() -> None:
         with (Path(github_workspace_dir) / Path(template_filename)).open() as f:
             template_data: str = f.read()
             logging.info("Rendering template from external file.")
-            rendered = pystache.render(template_data, data)
+            rendered = chevron.render(template_data, data)
     else:
         logging.info("Rendering default template.")
-        rendered = pystache.render(TEMPLATE, data)
+        rendered = chevron.render(TEMPLATE, data)
 
     # Write rendered data out to file
     logging.info(f"Writing rendered data to: {write_filename}")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request replaces uses of [pystache] with [chevron].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We originally started migrating to [chevron] from [pystache] because the last release of [pystache] at the time was in 2014. While [pystache] has since seen a [fork](https://github.com/PennyDreadfulMTG/pystache) that has updated it the same year as the last [chevron] release (end of 2021 for [pystache] vs beginning of 2021 for [chevron]) support for Python 2.7 was dropped in the new release. Since we have some Python 2 projects in our portfolio it is better to standardize on a library that supports both Python 2 and 3 so migrating to [chevron] still makes sense.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this branch in [this run](https://github.com/cisagov/action-apb/actions/runs/3683087415/jobs/6231493351) which ran successfully.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass (except `lint` from an outdated pre-commit configuration and Python 3.6 from an issue with the new Ubuntu 22.04 GHA runners).

[chevron]: https://github.com/noahmorrison/chevron
[pystache]: https://github.com/defunkt/pystache