### PR TITLE
Update build status badge link URL

### DIFF
--- a/src/apb_dashboard/_version.py
+++ b/src/apb_dashboard/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/apb_dashboard/entrypoint.py
+++ b/src/apb_dashboard/entrypoint.py
@@ -22,7 +22,7 @@ TEMPLATE = """
 |------------|--------------|-----------|------------|
 {{#repositories}}
 | {{repository}} \
-| {{#workflow}}[![GitHub Build Status](https://github.com/{{repository}}/workflows/build/badge.svg)](https://github.com/{{repository}}/actions){{/workflow}} \
+| {{#workflow}}[![GitHub Build Status](https://github.com/{{repository}}/actions/workflows/build.yml/badge.svg)](https://github.com/{{repository}}/actions){{/workflow}} \
 {{^workflow}}No workflow{{/workflow}} \
 | {{run_age}} \
 | {{event_sent}} |


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the format of the build status badge URL that appears in the Mustache template.

## 💭 Motivation and context ##

I'm not sure what happens on the backend, but using the newer URL format seems to give more reliable results.  Right now, for instance, [the old URL format](https://github.com/cisagov/skeleton-ansible-role-with-test-user/workflows/build/badge.svg) indicates failure for [cisagov/skeleton-ansible-role-with-test-user](https://github.com/cisagov/skeleton-ansible-role-with-test-user) while [the new URL format](https://github.com/cisagov/skeleton-ansible-role-with-test-user/actions/workflows/build.yml/badge.svg) correctly indicates success.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
